### PR TITLE
Add support for easy mode

### DIFF
--- a/js/fps.js
+++ b/js/fps.js
@@ -34,9 +34,24 @@ var frameTimes = [];              // Recent frame times
 // Method to get from URL params (if present)
 const queryString = window.location.search;
 const urlParams = new URLSearchParams(queryString);
+
 function getURLParamIfPresent(name, defaultValue){
-  if(urlParams.has(name)) return defaultValue.constructor(urlParams.get(name));
-  else return defaultValue;
+  var value = defaultValue;
+  if(urlParams.has(name)) {
+    // Special case for handling boolean strings
+    if (typeof defaultValue == "boolean"){     
+        value = (urlParams.get(name).toLowerCase() == 'true');
+        // Warning message for other strings as booleans
+        if(!value && urlParams.get(name).toLowerCase() != 'false') {
+          console.warn('Value "%s" (specified for boolean URL parameter "%s") is not "true" or "false" but should be, interpreting as "false"!', urlParams.get(name), name);
+        }
+    }
+    else { // Default case for type conversion from default value
+      value = defaultValue.constructor(urlParams.get(name));
+    }
+    console.log(name, value);   // Log settings to the console
+  }
+  return value;
 }
 
 // Base config

--- a/js/fps.js
+++ b/js/fps.js
@@ -191,7 +191,7 @@ const GameInputEventType = Object.freeze({
   "DESIRED_CAMERA_ROTATION":{},
 });
 
-var RawInputState = function ( mouseSensitivity = config.player.mouseSensitivity, speed = config.player.speed ) {
+var RawInputState = function ( frameDelay = config.render.frameDelay, mouseSensitivity = config.player.mouseSensitivity, speed = config.player.speed ) {
   var scope = this;
   scope.enabled = false;
   scope.perFrameEventQueue = [];
@@ -200,7 +200,7 @@ var RawInputState = function ( mouseSensitivity = config.player.mouseSensitivity
   scope.playerVelocity = new THREE.Vector3();
   scope.cameraPosition = new THREE.Vector3();
   scope.cameraRotation = new THREE.Euler(0.0, 0.0, 0.0, "ZYX"); // Euler angles of the camera
-  scope.frameDelay = 0;
+  scope.frameDelay = Math.round(frameDelay);
 
   var moveForward = false; var moveBackward = false; var moveLeft = false; var moveRight = false;
   var run = false;

--- a/js/fps.js
+++ b/js/fps.js
@@ -30,125 +30,134 @@ var frameTimeValid = false;       // Has the frame time converged?
 var frameTimes = [];              // Recent frame times
 
 // Configuration
-var config = { 
-  
-  render : {
-    setFPS : false,               // Allow in application FPS setting (changes animation approach!)
-    frameRate : 60,               // Frame rate to use (if setFPS is true only)
-    frameDelay: 0,                // Frame delay to apply to incoming user events
-    hFov : 103,                   // Horizontal camera field of view
-    showStatistics : false,       // Show rendering statistics (frame rate/time and memory widget)
-    showBanner : true,            // Show the score banner
-    fullscreen: true,             // Show in fullscreen mode (if available)
-    latewarp: false,               // Enable late warp
 
-    c2p : {                       // Click-to-photon configuration
-      show : false,               // Show the click to photon area
-      vertPos : 0.5,              // Set the vertical postiion along the left edge of the screen
-      mode: 'immediate',          // Mode (either minimal system latency = "immediate" or including frame delay = "delayed")
-      width: 0.2,                 // Width of the click to photon area
-      height: 0.2,                // Height of the click to photon area
-      upColor : '#222222',        // Click to photon mouse down color
-      downColor: '#AAAAAA',       // Click to photon mouse up color
+// Method to get from URL params (if present)
+const queryString = window.location.search;
+const urlParams = new URLSearchParams(queryString);
+function getURLParamIfPresent(name, defaultValue){
+  if(urlParams.has(name)) return defaultValue.constructor(urlParams.get(name));
+  else return defaultValue;
+}
+
+// Base config
+var config = {
+
+  render : { // Render configuration
+    setFPS : getURLParamIfPresent('setFPS', false),               // Allow in application FPS setting (changes animation approach!)
+    frameRate : getURLParamIfPresent('frameRate', 60),            // Frame rate to use (if setFPS is true only)
+    frameDelay: getURLParamIfPresent('frameDelay', 0),            // Frame delay to apply to incoming user events
+    hFov : getURLParamIfPresent('hFoV', 103),                     // Horizontal camera field of view
+    showStatistics : getURLParamIfPresent('showStats', false),    // Show rendering statistics (frame rate/time and memory widget)
+    showBanner : getURLParamIfPresent('showBanner', true),        // Show the score banner
+    fullscreen: getURLParamIfPresent('fullscreen', true),         // Show in fullscreen mode (if available)
+    latewarp: getURLParamIfPresent('latewarp', false),            // Enable late warp
+
+    c2p : { // Click-to-photon configuration
+      show : getURLParamIfPresent('showC2P', false),               // Show the click to photon area
+      vertPos : getURLParamIfPresent('c2pVertPos', 0.5),           // Set the vertical postiion along the left edge of the screen
+      mode: getURLParamIfPresent('c2pMode', 'immediate'),          // Mode (either minimal system latency = "immediate" or including frame delay = "delayed")
+      width: getURLParamIfPresent('c2pWidth', 0.2),                // Width of the click to photon area
+      height: getURLParamIfPresent('c2pHeight', 0.2),              // Height of the click to photon area
+      upColor : getURLParamIfPresent('c2pUpColor', '#222222'),     // Click to photon mouse down color
+      downColor: getURLParamIfPresent('c2pDownColor', '#AAAAAA'),  // Click to photon mouse up color
     }
   },
 
-  audio : {
-    fireSound : true,             // Play shot sound?
-    explodeSound : true,          // Play explode sound?
-    delayMs: 0,                  // Audio delay in milliseconds
+  audio : { // Audio parameters
+    fireSound : getURLParamIfPresent('playFireSound', true),       // Play shot sound?
+    explodeSound : getURLParamIfPresent('playExplodeSound', true), // Play explode sound?
+    delayMs: getURLParamIfPresent('audioDelaMs', 0),               // Audio delay in milliseconds
   },
 
-  scene : {
-    skyColor : '#c6defa',         // Skybox color
-    useCubeMapSkyBox : false,     // Skybox use cube map?
-    width : 1000,                 // Width of the scene
-    depth : 1000,                 // Depth of the scene
-    floorColor: '#756b5a',        // Color of the floor
+  scene : { // Scene parameters
+    skyColor : getURLParamIfPresent('skyColor', '#c6defa'),         // Skybox color
+    useCubeMapSkyBox : getURLParamIfPresent('cubemapSky', false),   // Skybox use cube map?
+    width : getURLParamIfPresent('sceneWidth', 1000),               // Width of the scene
+    depth : getURLParamIfPresent('sceneDepth', 1000),               // Depth of the scene
+    floorColor: getURLParamIfPresent('floorColor', '#756b5a'),      // Color of the floor
     
-    fog : {                       // Fog parameters
-      color: '#ffffff',           // Fog color
-      nearDistance: 0,            // Near distance for fog (no fog here) for linear interpolation
-      farDistance: 1000           // Far distance for fog (max fog here) for linear interpolation
+    fog : { // Fog parameters
+      color: getURLParamIfPresent('fogColor', '#ffffff'),           // Fog color
+      nearDistance: getURLParamIfPresent('fogNear', 0),             // Near distance for fog (no fog here) for linear interpolation
+      farDistance: getURLParamIfPresent('fogFar', 1000),            // Far distance for fog (max fog here) for linear interpolation
     },
     
-    walls : {                     // Map bounds (walls) configuration
-      color: '#2a2713',           // Color of the walls
-      height: 80,                 // Height of the walls
+    walls : { // Map bounds (walls) configuration
+      color: getURLParamIfPresent('wallColor', '#2a2713'),          // Color of the walls
+      height: getURLParamIfPresent('wallHeight', 80),               // Height of the walls
     },
     
-    boxes : {                     // Boxes (map geometry) configuration
-      count: 200,                 // Number of boxes to create per scene
-      minHeight: 20,              // Minimum box height
-      maxHeight: 100,             // Maximum box height
-      width : 20,                 // Box width (same for all)
-      depth : 20,                 // Box depth (same for all)
-      distanceRange : 500,        // Range of distances over which to spawn boxes
-      minDistanceToPlayer: 80,    // Minimum distance from any box center to player spawn position (origin)
-      color: '#ffffff',           // Base color for boxes
-      colorScaleRange: 0.5        // Amount to allow randomized scaling of color for each box
+    boxes : { // Boxes (map geometry) configuration
+      count: getURLParamIfPresent('boxCount', 200),                       // Number of boxes to create per scene
+      minHeight: getURLParamIfPresent('boxMinHeight', 20),                // Minimum box height
+      maxHeight: getURLParamIfPresent('boxMaxHeight', 100),               // Maximum box height
+      width : getURLParamIfPresent('boxWidth', 20),                       // Box width (same for all)
+      depth : getURLParamIfPresent('boxDepth', 20),                       // Box depth (same for all)
+      distanceRange : getURLParamIfPresent('boxRange', 500),              // Range of distances over which to spawn boxes
+      minDistanceToPlayer: getURLParamIfPresent('boxMinDistance', 80),    // Minimum distance from any box center to player spawn position (origin)
+      color: getURLParamIfPresent('boxColor', '#ffffff'),                 // Base color for boxes
+      colorScaleRange: getURLParamIfPresent('boxColorScale', 0.5),        // Amount to allow randomized scaling of color for each box
     },
   },
 
-  player : {
-    speed : 500,                  // Speed of player motion
-    mouseSensitivity : 0.2,       // Mouse sensitivty for view direction
-    height : 5,                   // Player view height
-    jumpHeight : 250,             // Player jump height
-    collisionDetection : true,    // Perform collision detection within the scene? 
-    collisionDistance : 3,        // Player collision distance (set to 0 for no collision)
+  player : { // Player configuration
+    speed : getURLParamIfPresent('playerSpeed', 500),                       // Speed of player motion
+    mouseSensitivity : getURLParamIfPresent('mouseSensitivity', 0.2),       // Mouse sensitivty for view direction
+    height : getURLParamIfPresent('playerHeight', 5),                       // Player view height
+    jumpHeight : getURLParamIfPresent('playerJumpHeight', 250),             // Player jump height
+    collisionDetection : getURLParamIfPresent('playerCollision', true),     // Perform collision detection within the scene? 
+    collisionDistance : getURLParamIfPresent('playerCollisionDistance', 3), // Player collision distance (set to 0 for no collision)
   },
 
-  reticle : {           
-    color : '#000000',            // Reticle color
-    //linewidth : 3,              // Reticle line width (unsupported!)
-    size : 0.03,                  // Reticle base size
-    gap : 0.01,                   // Reticle base gap size
-    thickness : 0.15,             // Reticle thickness (ratio of size)
-    expandedScale : 2,            // Reticle expanded scale
-    shrinkTime : 0.3              // Reticle shrink time after fire event
+  reticle : { // Reticle configuration
+    color : getURLParamIfPresent('reticleColor', '#000000'),                // Reticle color
+    size : getURLParamIfPresent('reticleSize', 0.03),                       // Reticle base size
+    gap : getURLParamIfPresent('reticleGap', 0.01),                         // Reticle base gap size
+    thickness : getURLParamIfPresent('reticleThickness', 0.15),             // Reticle thickness (ratio of size)
+    expandedScale : getURLParamIfPresent('reticleExpandScale', 2),          // Reticle expanded scale
+    shrinkTime : getURLParamIfPresent('reticleShrinkTimeS', 0.3),           // Reticle shrink time after fire event
   },
 
-  targets : {   
-    count: 1,                     // Number of simultaneous targets         
-    minSize : 0.5,                // Minimum target size (uniform random in range)
-    maxSize : 3,                  // Maxmium target size (uniform random in range)
-    minSpeed: 5,                  // Minimum target speed (uniform random in range)
-    maxSpeed : 15,                // Maximum target speed (uniform random in range)
-    minChangeTime : 1,            // Minimum target direction change time (uniform random in range)
-    maxChangeTime : 3,            // Maximum target direction change tiem (uniform random in range)
-    fullHealthColor : '#00ff00',  // Color for full health target
-    minHealthColor : '#ff0000',   // Color for min health 
+  targets : { // Task target configuration
+    count: getURLParamIfPresent('targetCount', 1),                              // Number of simultaneous targets         
+    minSize : getURLParamIfPresent('targetMinSize', 0.5),                       // Minimum target size (uniform random in range)
+    maxSize : getURLParamIfPresent('targetMaxSize', 3),                         // Maxmium target size (uniform random in range)
+    minSpeed: getURLParamIfPresent('targetMinSpeed', 5),                        // Minimum target speed (uniform random in range)
+    maxSpeed : getURLParamIfPresent('targetMaxSpeed', 15),                      // Maximum target speed (uniform random in range)
+    minChangeTime : getURLParamIfPresent('targetMinChangeTime', 1),             // Minimum target direction change time (uniform random in range)
+    maxChangeTime : getURLParamIfPresent('targetMaxChangeTime' , 3),            // Maximum target direction change tiem (uniform random in range)
+    fullHealthColor : getURLParamIfPresent('targetMaxHealthColor', '#00ff00'),  // Color for full health target
+    minHealthColor : getURLParamIfPresent('targetMinHealthColor', '#ff0000'),   // Color for min health 
     
-    minSpawnDistance: 20,         // Minimum target spawn distance
-    maxSpawnDistance: 30,         // Maximum target spawn distance
-    spawnAzimRangeDeg : 35,       // The ± range of target spawn azimuth angle (relative to current view direction)
-    spawnElevRangeDeg : 10,       // The ± range of target spawn elevation angle (relative to current view direction)
+    minSpawnDistance: getURLParamIfPresent('targetMinSpawnDistance', 20),   // Minimum target spawn distance
+    maxSpawnDistance: getURLParamIfPresent('targetMaxSpawnDistance', 30),   // Maximum target spawn distance
+    spawnAzimRangeDeg : getURLParamIfPresent('targetSpawmRangeAzim', 35),   // The ± range of target spawn azimuth angle (relative to current view direction)
+    spawnElevRangeDeg : getURLParamIfPresent('targetSpawnRangeElev', 10),   // The ± range of target spawn elevation angle (relative to current view direction)
 
-    collisionDetection : true,    // Target collision detection (bounce)
-    collisionDistance : 3,        // Target collision distance
-    keepInSceneMinDistance: true, // Keep the target within the scene.boxes.minDistanceToPlayer
+    collisionDetection : getURLParamIfPresent('targetCollision', true),           // Target collision detection (bounce)
+    collisionDistance : getURLParamIfPresent('targetCollisionDistance', 3),       // Target collision distance
+    keepInSceneMinDistance: getURLParamIfPresent('keepTargetInClearning', true),  // Keep the target within the scene.boxes.minDistanceToPlayer
 
-    reference : {                 // Reference target configuration
-      size: 1,                    // Reference target size
-      distance: 30,               // Reference target distance
+    reference : { // Reference target configuration
+      size: getURLParamIfPresent('refTargetSize', 1),             // Reference target size
+      distance: getURLParamIfPresent('refTargetDistance', 30),    // Reference target distance
     },
 
-    particles : {     
-      size: 0.4,                  // Particle size for hitting/destroying the target
-      hitCount: 25,               // Particle count for hitting the target
-      destroyCount: 1000,         // Particle count for destroying the target
+    particles : { // Particle effect configuration
+      size: getURLParamIfPresent('particleSize', 0.4),                      // Particle size for hitting/destroying the target
+      hitCount: getURLParamIfPresent('hitParticleCount', 25),               // Particle count for hitting the target
+      destroyCount: getURLParamIfPresent('destroyParticleCount', 1000),     // Particle count for destroying the target
     }
   },
 
-  weapon : {           
-    auto : false,                 // Automatic firing (hold mouse to fire?)
-    firePeriod : 0.1,             // Fire period limit (minimum time between shots)
-    damagePerSecond : 10,         // Damage per second (per shot = damagePerSecond * fireRate)
-    scoped : false,               // Allow "scoped" or zoomed view?
-    toggleScope : true,           // Toggle scope with left mouse? (false means hold left mouse for scope)
-    scopeFov : 50,                // Field of view when scoped
-    fireSpread: 0.5,                // Fire spread (symmetric in degrees)                  
+  weapon : { // Weapon configuration
+    auto : getURLParamIfPresent('weaponAuto', false),               // Automatic firing (hold mouse to fire?)
+    firePeriod : getURLParamIfPresent('weaponFirePeriod', 0.1),     // Fire period limit (minimum time between shots)
+    damagePerSecond : getURLParamIfPresent('weaponDPS', 10),        // Damage per second (per shot = damagePerSecond * fireRate)
+    scoped : getURLParamIfPresent('weaponScope', false),            // Allow "scoped" or zoomed view?
+    toggleScope : getURLParamIfPresent('weaponScopeToggle', true),  // Toggle scope with left mouse? (false means hold left mouse for scope)
+    scopeFov : getURLParamIfPresent('weaponScopeFoV', 50),          // Field of view when scoped
+    fireSpread: getURLParamIfPresent('weaponFireSpread', 0.5),      // Fire spread (symmetric in degrees)                  
   }
 };
 

--- a/js/fps.js
+++ b/js/fps.js
@@ -246,7 +246,7 @@ var config = {
   targets : { // Task target configuration
     count: getURLParamIfPresent('targetCount', 1),                              // Number of simultaneous targets         
     minSize : getURLParamIfPresent('targetMinSize', 0.5),                       // Minimum target size (uniform random in range)
-    maxSize : getURLParamIfPresent('targetMaxSize', 3),                         // Maxmium target size (uniform random in range)
+    maxSize : getURLParamIfPresent('targetMaxSize', 1.5),                       // Maxmium target size (uniform random in range)
     minSpeed: getURLParamIfPresent('targetMinSpeed', 5),                        // Minimum target speed (uniform random in range)
     maxSpeed : getURLParamIfPresent('targetMaxSpeed', 15),                      // Maximum target speed (uniform random in range)
     minChangeTime : getURLParamIfPresent('targetMinChangeTime', 1),             // Minimum target direction change time (uniform random in range)
@@ -290,8 +290,8 @@ var config = {
 if(mode == 'easy'){   
   config.targets.minSpeed = 8;
   config.targets.maxSpeed= 10;
-  config.targets.minSize = 1;
-  config.targets.maxSize = 2;
+  config.targets.minSize = 2;
+  config.targets.maxSize = 2.5;
 }
 
 function exportConfig(){

--- a/js/fps.js
+++ b/js/fps.js
@@ -46,8 +46,8 @@ var config = {
     setFPS : getURLParamIfPresent('setFPS', false),               // Allow in application FPS setting (changes animation approach!)
     frameRate : getURLParamIfPresent('frameRate', 60),            // Frame rate to use (if setFPS is true only)
     frameDelay: getURLParamIfPresent('frameDelay', 0),            // Frame delay to apply to incoming user events
-    hFov : getURLParamIfPresent('hFoV', 103),                     // Horizontal camera field of view
-    showStatistics : getURLParamIfPresent('showStats', false),    // Show rendering statistics (frame rate/time and memory widget)
+    hFoV : getURLParamIfPresent('hFoV', 103),                     // Horizontal camera field of view
+    showStats : getURLParamIfPresent('showStats', false),         // Show rendering statistics (frame rate/time and memory widget)
     showBanner : getURLParamIfPresent('showBanner', true),        // Show the score banner
     fullscreen: getURLParamIfPresent('fullscreen', true),         // Show in fullscreen mode (if available)
     latewarp: getURLParamIfPresent('latewarp', false),            // Enable late warp
@@ -66,7 +66,7 @@ var config = {
   audio : { // Audio parameters
     fireSound : getURLParamIfPresent('playFireSound', true),       // Play shot sound?
     explodeSound : getURLParamIfPresent('playExplodeSound', true), // Play explode sound?
-    delayMs: getURLParamIfPresent('audioDelaMs', 0),               // Audio delay in milliseconds
+    delayMs: getURLParamIfPresent('audioDelayMs', 0),              // Audio delay in milliseconds
   },
 
   scene : { // Scene parameters
@@ -115,7 +115,7 @@ var config = {
     gap : getURLParamIfPresent('reticleGap', 0.01),                         // Reticle base gap size
     thickness : getURLParamIfPresent('reticleThickness', 0.15),             // Reticle thickness (ratio of size)
     expandedScale : getURLParamIfPresent('reticleExpandScale', 2),          // Reticle expanded scale
-    shrinkTime : getURLParamIfPresent('reticleShrinkTimeS', 0.3),           // Reticle shrink time after fire event
+    shrinkTime : getURLParamIfPresent('reticleShrinkTime', 0.3),           // Reticle shrink time after fire event
   },
 
   targets : { // Task target configuration
@@ -394,7 +394,7 @@ THREE.FirstPersonControls = function ( camera, scene, jumpHeight = config.player
     case GameInputEventType.TOGGLE_SCOPE:
       if(config.weapon.toggleScope) inScopeView = !inScopeView;
       else inScopeView = true;
-      camera.fov = (inScopeView ? config.weapon.scopeFov : config.render.hFov) / camera.aspect;
+      camera.fov = (inScopeView ? config.weapon.scopeFov : config.render.hFoV) / camera.aspect;
       camera.updateProjectionMatrix();
       break;
     case GameInputEventType.DESIRED_VELOCITY:
@@ -909,11 +909,11 @@ function makeGUI() {
 
   // Render controls
   var renderControls = gui.addFolder('Rendering');
-  renderControls.add(config.render, 'showStatistics').name('Show Stats').listen().onChange(function(value){
-    statsContainer.style.visibility = config.render.showStatistics ? 'visible' : 'hidden';
+  renderControls.add(config.render, 'showStats').name('Show Stats').listen().onChange(function(value){
+    statsContainer.style.visibility = config.render.showStats ? 'visible' : 'hidden';
   });
   renderControls.add(config.render, 'fullscreen').name('Fullscreen?').listen();
-  statsContainer.style.visibility = config.render.showStatistics ? 'visible' : 'hidden';
+  statsContainer.style.visibility = config.render.showStats ? 'visible' : 'hidden';
   renderControls.add(config.render, 'setFPS').name('Set FPS').listen().onChange(function(value){
     setGuiElementEnabled(fpsSlider, value);
   });
@@ -926,7 +926,7 @@ function makeGUI() {
   renderControls.add(config.render, 'latewarp').name('Late Warp?').listen().onChange(function(value){
     drawReticle();
   });
-  renderControls.add(config.render, 'hFov', 10, 130, 1).name('Field of View').listen().onChange(function(value){
+  renderControls.add(config.render, 'hFoV', 10, 130, 1).name('Field of View').listen().onChange(function(value){
     camera.fov = value / camera.aspect;
     camera.updateProjectionMatrix();
     drawC2P();
@@ -1104,7 +1104,7 @@ function makeGUI() {
   });
   var scopeControls = weaponControls.addFolder('Scope');
   scopeControls.add(config.weapon, 'toggleScope').name('Toggle Scope').listen();
-  scopeControls.add(config.weapon, 'scopeFov', 10, config.render.hFov).step(1).name('Scope FoV').listen();
+  scopeControls.add(config.weapon, 'scopeFov', 10, config.render.hFoV).step(1).name('Scope FoV').listen();
   setGuiElementEnabled(scopeControls, config.weapon.scoped);
   
   var importExport = gui.addFolder('Config Import/Export');
@@ -1204,7 +1204,7 @@ var processMouseDown = function(event){
   if(event.button == 2 && config.weapon.scoped) {
     if(config.weapon.toggleScope) inScopeView = !inScopeView;
     else inScopeView = true;
-    camera.fov = (inScopeView ? config.weapon.scopeFov : config.render.hFov) / camera.aspect;
+    camera.fov = (inScopeView ? config.weapon.scopeFov : config.render.hFoV) / camera.aspect;
     camera.updateProjectionMatrix();
   }
 };
@@ -1230,7 +1230,7 @@ var processMouseUp = function(event){
   }
   if(event.button == 2 && config.weapon.scoped && !config.weapon.toggleScope){
     inScopeView = false;
-    camera.fov = (inScopeView ? config.weapon.scopeFov : config.render.hFov) / camera.aspect;
+    camera.fov = (inScopeView ? config.weapon.scopeFov : config.render.hFoV) / camera.aspect;
     camera.updateProjectionMatrix();
   }
 }

--- a/js/fps.js
+++ b/js/fps.js
@@ -37,6 +37,7 @@ var conditionsToRun = ["T", "0", "80", "80W"];
 
 var inTraining = true;              // Start in training mode
 var sandboxMode = false;            // Developer mode flag (direct to sandbox mode)
+var easyMode = false;               // Easier to hit targets
 var randomizeOrder = false;         // Randomize session order
 
 var defaultFrameRateHz = 60;        // Assumed default frame rate
@@ -47,7 +48,10 @@ if(urlParams.has('trainingTargets')){ trainingTargets = urlParams.get('trainingT
 if(urlParams.has('targetsPerCondition')){ targetsPerCondition = urlParams.get('targetsPerCondition'); }
 if(urlParams.has('conditions')){ conditionsToRun = urlParams.get('conditions').split(','); }
 if(urlParams.has('randomizeOrder')) { randomizeOrder = urlParams.get('randomizeOrder'); }
-if(urlParams.has('mode')) { sandboxMode = urlParams.get('mode') == 'sandbox'}
+if(urlParams.has('mode')) { 
+  sandboxMode = urlParams.get('mode') == 'sandbox';
+  easyMode = urlParams.get('mode') == 'easy';
+}
 
 if(sandboxMode) {                       // Developer overrides for testing (comes from configuration.js)
   conditionsToRun = [];             // Empty array goes straight into sandbox mode
@@ -275,6 +279,14 @@ var config = {
     fireSpread: 0.5,                // Fire spread (symmetric in degrees)                  
   }
 };
+
+// Change target size and speed if in easy mode
+if(easyMode){   
+  config.targets.minSpeed = 8;
+  config.targets.maxSpeed= 10;
+  config.targets.minSize = 1;
+  config.targets.maxSize = 2;
+}
 
 function exportConfig(){
   var a = document.createElement('a');

--- a/readme.md
+++ b/readme.md
@@ -21,65 +21,100 @@ To run with local host the top-level directory for this project needs to be host
 After hosting the directory through `localhost` the application can be accessed by visiting `http://localhost:8000/index.html`.
 
 ## Supported Configuration
-A variety of configuration from the (Windows) FPSci application is supported in this application, including:
+A variety of configuration from the (Windows) FPSci application is supported in this application. The application can be configured either through loading a JSON file from disk, or by using URL parameters.
+
+Currently supported configuration is provided as a nested list below. The format is: [Parameter Name]: [`URL Parameter Name`] (`type`) = [Default Value].
+
+Typically JSON parameter names are _very_ similar to URL parameter names, but often with less verbosity as they are inherently nested in the configuration dictionary.
 
 * Rendering
-    * Frame rate
-    * Frame delay
-    * Late warp correction
-    * Field of View (horizontal)
+    * Set frame rate?: `setFPS` (`Boolean`) = `False`
+    * Frame rate: `frameRate` (`Number`) = `60`
+    * Frame delay: `frameDelay` (`Integer`) = `0`
+    * Late warp correction?: `latewarp` (`Boolean`) = `False`
+    * Field of View (horizontal): `hFoV` (`Number`) = `103`
+    * Show rendering statistics?: `showStats` (`Boolean`) = `False`
+    * Show score banner?: `showBanner` (`Boolean`) = `True`
+    * Fullscreen mode?: `fullscreen` (`Boolean`) = `True`
     * Click-to-photon monitoring
+        * Show click to photon-monitor?: `showC2P` (`Boolean`) = `False`
+        * Certical position: `c2pVertPos` (`Boolean`) = `0.5`
+        * Output mode: `c2pMode` (`"immediate"` or `"delayed"`) = `"immediate"`
+        * Width of area: `c2pWidth` (`Number` 0-1) = `0.2`
+        * Height of area: `c2pHeight` (`Number` 0-1) = `0.2`
+        * Mouse up color: `c2pUpColor` (`Color`) = `#222222`
+        * Mouse down color: `c2pDownColor` (`Color`) = `#AAAAAA`
 * Audio
-    * Play fire audio?
-    * Play target explision audio?
-    * Add audio latency
+    * Play fire audio?: `playFireSound` (`Boolean`) = `True`
+    * Play target explision audio?: `playExplodeSound` (`Boolean`) = `True`
+    * Added audio latency: `AudioDelayMs` (`Number`) = `0`
 * Scene - Generated, so different from FPSci
-    * Overall width/depth
-    * Sky color/use of a cubemap-based skybox (requries local hosting)
-    * Floor color
-    * Fog color and distances
-    * Wall height and color (for edge of the scene)
+    * Sky color (no cubemap): `skyColor` (`Color`) = `#c6defa`
+    * Use a cubemap-based skybox?: `cubemapSky` (`Boolean`) = `False`
+    * Scene width: `sceneWidth` (`Number`) = `1000`
+    * Scene depth: `sceneDepth` (`Number`) = `1000`
+    * Floor color: `floorColor` (`Color`) = `#756b5a`
+    * Fog 
+        * Color: `fogColor` (`Color`) = `#ffffff`
+        * Near distance: `fogNear` (`Number`) = `0`
+        * Far distance: `fogFar` = `1000`
+    * Walls (scene bounds)
+        * Color: `wallColor` (`Color`) = `#2a2713`
+        * Height: `wallHeight` (`Number`) = `80`
     * Boxes (geometry within the scene)
-        * Count of boxes
-        * Box geometry (width, depth, height range)
-        * Distance from boxes to player spawn postion
-        * Base color
-        * Color scale range (randomized within for individual boxes)
-    * Regenerate a new (random) scene based on parameters above
+        * Count of boxes: `boxCount` (`Integer`) = `200`
+        * Min height (uniform random in range): `boxMinHeight` (`Number`) = `20`
+        * Max height (uniform random in range): `boxMaxHeight` (`Number`) = `100`
+        * Width (same for all): `boxWidth` (`Number`) = `20`
+        * Depth (same for all): `boxDepth` (`Number`) = `20`
+        * Distance from boxes to player spawn postion: `boxRange` (`Number`) = `500`
+        * Minimum distance from box to player (clearing size): `boxMinDistance` (`Number`) = `80`
+        * Base color (scaled): `boxColor` (`Color`) = `#ffffff`
+        * Color scale range (randomized range): `boxColorScale` (`Number` 0-1) = `0.5`
+    * _Regenerate a new (random) scene based on parameters above using a button or by reloading_
 * Player
-    * Mouse sensitivity (arbitrary units)
-    * Height
-    * Speed
-    * Jump Height
-    * Collision detection (within the scene)
-    * Reticle
-        * Color
-        * Base size (extents)
-        * Gap size
-        * Expanded scale (after a shot)
-        * Shrink time (after a shot)
+    * Movement Speed: `playerSpeed` (`Number`) = `500`
+    * Mouse sensitivity (arbitrary units): `mouseSensitivity` (`Number`) = `0.2`
+    * Height: `playerHeight` (`Number`) = `5`
+    * Jump Height: `playerJumpHeight` (`Number`) = `250`
+    * Collision detection (within the scene): `playerCollision` (`Boolean`) = `True`
+    * Collision distance: `playerCollisionDistance` (`Number`) = `3`
+    * Reticle (aim direction indicator)
+        * Color: `reticleColor` (`Color`) = `#000000`
+        * Base size (extents): `reticleSize` (`Number`) = `0.03`
+        * Gap size: `reticleGap` (`Number`) = `0.01`
+        * Expanded scale (after a shot): `reticleExpandScale` (`Number` ratio) = `2`
+        * Shrink time (after a shot): `reticleShrinkTime` (`Number` seconds) = `0.3`
 * Target
-    * Count (simultaneous targets)
+    * Count (simultaneous targets): `targetCount` (`Integer`) = `1`
+    * Min size (uniform random in range): `targetMinSize` (`Number`) = `0.5`
+    * Max size (uniform random in range): `targetMaxSize` (`Number`) = `3`
+    * Movement parameters (uniformly randomized in range)
+        * Min speed (along a line): `targetMinSpeed` (`Number`) = `5`
+        * Max speed (along a line): `targetMaxSpeed` (`Number`) = `15`
+        * Min motion change time (new direction selection interval): `targetMinChangeTime` (`Number`) = `1`
+        * Max motion change time (new direction selection interval): `targetMaxChangeTime` (`Number`) = `3`
     * Color (full/min health are interpolated between)
-    * Size (min/max randomized)
-    * Movement parameters (randomized)
-        * Min/max speed
-        * Min/max change time
-    * Spawn position (randomized in range)
-        * Azimuth/Elevation range (relative to most recent player view)
-        * Min/max distance
-    * Particles (drawn on hit)
-        * Size
-        * Count to spawn on hit
-        * Count to spawn on destroy
-    * Reference target
-        * Size
-        * Distance
+        * Full/max health color: `targetMaxHealthColor` (`Color`) = `#00ff00`
+        * Min/no health color: `targetMinHealthColor` (`Color`) = `#ff0000`
+    * Spawn position (uniformly randomized in range)
+        * Min spawn distance: `targetMinSpawnDistance` (`Number`): `20`
+        * Max spawn distance: `targetMaxSpawnDistance` (`Number`): `30`
+        * Azimuth spawn angle (± relative to most recent player view): `targetSpawnRangeAzim` (`Number` degrees) = `35`
+        * Elevation spawn angle (± relative to most recent player view): `targetSpawnRangeElev` (`Number` degrees) = `10`
+    * Reference target (red target used to reset aim direction on reload/start of trial)
+        * Size: `refTargetSize` (`Number`) = `1`
+        * Distance: `refTargetDistance` (`Number`) = `30`
+    * Particles (drawn on hit/destory events)
+        * Size: `particleSize` (`Number`): `0.4`
+        * Count to spawn on hit: `hitParticleCount` (`Integer`) = `25`
+        * Count to spawn on destroy: `destroyParticleCount` (`Integer`) = `1000`
 * Weapon
-    * Automatic fire
-    * Fire period 
-    * Damage/s (multiply by fire period to get damage/shot)
+    * Automatic fire (hold left mouse to fire): `weaponAuto` (`Boolean`) = `False`
+    * Fire period (rate of fire): `weaponFirePeriod` (`Number`) = `0.1` (10 shots per s ==> 600 rounds per minute)
+    * Damage/s (multiply by fire period to get damage/shot): `weaponDPS` (`Number`) = `10` (1-hit destroy as all targets have 1 life)
+    * Fire spread angle (symmetric): `weaponFireSpread` (`Number` degrees) = `0.5`
     * Scope controls
-        * Has scope?
-        * Toggle vs hold for scope
-        * Field of view when scoped
+        * Has scope?: `weaponScope` (`Boolean`) = `False`
+        * Toggle vs hold for scope: `weaponScopeToggle` (`Boolean`) = `True` (toggled scope by default)
+        * Field of view when scoped: `weaponScopeFoV` (`Number`) = `50`


### PR DESCRIPTION
This branch adds support for an "easy" mode w/ larger, slower moving targets for less skilled users. The effects of late warp may not be as pronounced, but this should provide an option for people less experienced in FPS gameplay.

You can set easy mode using the existing `mode` URL param as follows (though this link will not actually work until this PR is merged): 
[https://nvlabs.github.io/FPSWarpDemo?mode=easy](https://nvlabs.github.io/FPSWarpDemo?mode=easy)

In the meantime you can test it using `[repo location]/index.html?mode=easy`