### PR TITLE
fix: browser may open before HTTP server is ready

### DIFF
--- a/open_localhost.bat
+++ b/open_localhost.bat
@@ -2,5 +2,6 @@
 :: This script requires a valid python installation in the user's path
 
 start py -m http.server 8000 
-timeout /t 1 /nobreak >nul
+:wait_for_server
+py -c "import socket; s=socket.socket(); s.settimeout(0.5); s.connect(('localhost',8000)); s.close()" >nul 2>&1 || (timeout /t 1 /nobreak >nul & goto :wait_for_server)
 start http://localhost:8000/index.html

--- a/open_localhost.bat
+++ b/open_localhost.bat
@@ -2,6 +2,12 @@
 :: This script requires a valid python installation in the user's path
 
 start py -m http.server 8000 
+set /a retries=0
 :wait_for_server
-py -c "import socket; s=socket.socket(); s.settimeout(0.5); s.connect(('localhost',8000)); s.close()" >nul 2>&1 || (timeout /t 1 /nobreak >nul & goto :wait_for_server)
+py -c "import socket; s=socket.socket(); s.settimeout(0.5); s.connect(('localhost',8000)); s.close()" >nul 2>&1 && goto :server_ready
+set /a retries=retries+1
+if %retries%==30 (echo HTTP server failed to start >&2 & exit /b 1)
+timeout /t 1 /nobreak >nul
+goto :wait_for_server
+:server_ready
 start http://localhost:8000/index.html

--- a/open_localhost.bat
+++ b/open_localhost.bat
@@ -2,4 +2,5 @@
 :: This script requires a valid python installation in the user's path
 
 start py -m http.server 8000 
+timeout /t 1 /nobreak >nul
 start http://localhost:8000/index.html


### PR DESCRIPTION
### Problem
fix: browser may open before HTTP server is ready

### Fix
Replace:
```
start py -m http.server 8000 
start http://localhost:8000/index.html
```

with:
```
start py -m http.server 8000 
timeout /t 1 /nobreak >nul
start http://localhost:8000/index.html
```

### Files changed
- `open_localhost.bat`