### PR TITLE
fix: browser may open before localhost server is ready

### DIFF
--- a/open_localhost.bat
+++ b/open_localhost.bat
@@ -2,4 +2,5 @@
 :: This script requires a valid python installation in the user's path
 
 start py -m http.server 8000 
+timeout /t 2 /nobreak >nul
 start http://localhost:8000/index.html


### PR DESCRIPTION
### Problem
fix: browser may open before localhost server is ready

### Fix
Replace:
```
start py -m http.server 8000 
start http://localhost:8000/index.html
```

with:
```
start py -m http.server 8000 
timeout /t 2 /nobreak >nul
start http://localhost:8000/index.html
```

### Files changed
- `open_localhost.bat`